### PR TITLE
refactor: avoid import default React

### DIFF
--- a/src/components/SelectableItem.tsx
+++ b/src/components/SelectableItem.tsx
@@ -1,20 +1,18 @@
-import { PropsWithChildren } from "react";
+import { HTMLAttributes, PropsWithChildren } from "react";
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  onSelect: () => void;
+interface Props extends HTMLAttributes<HTMLDivElement> {
   className?: string;
   id: string;
 }
 
 export default function SelectableItem({
   children,
-  onSelect,
   id,
   className,
   ...props
 }: PropsWithChildren<Props>) {
   return (
-    <div id={id} onClick={onSelect} className={className} {...props}>
+    <div id={id} className={className} {...props}>
       {children}
     </div>
   );

--- a/src/hooks/useSelectionZone.ts
+++ b/src/hooks/useSelectionZone.ts
@@ -1,8 +1,8 @@
-import { useCallback, useRef, useState } from "react";
+import { type MouseEvent, useCallback, useRef, useState } from "react";
 import { CollisionType, TSelectableItem, TSelection } from "../shared/types";
 
 type HandleMouseMoveCBProps<T> = {
-  e: React.MouseEvent;
+  e: MouseEvent;
   selection: TSelection;
   isSelecting: boolean;
   items: T[];
@@ -51,7 +51,7 @@ export const useSelectionZone = <T extends TSelectableItem>({
 
   const selectionContainerRef = useRef<HTMLDivElement>(null);
 
-  const handleMouseDown = (e: React.MouseEvent) => {
+  const handleMouseDown = (e: MouseEvent) => {
     const selectionContainerRefCurrent = selectionContainerRef.current;
     if (!selectionContainerRefCurrent) return;
 


### PR DESCRIPTION
refactor: remove reference to React - to avoid implicit import default React from react